### PR TITLE
Bump zipkin and zipkin-transport-http versions to remove accept header

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,3 +5,4 @@ Authors ordered by first contribution
  - Aaron Collins (aaron.collins1@ibm.com)
  - Chris Bailey (BAILEYC@uk.ibm.com)
  - Eli Goldberg (eli.b.goldberg@gmail.com)
+ - Krisztian Toth (selator@gmail.com)

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "dependencies": {
     "properties-reader": "0.0.16",
     "tcp-ping": "^0.1.1",
-    "zipkin": "0.10.1",
+    "zipkin": "0.11.1",
     "zipkin-context-cls": "0.6.1",
-    "zipkin-transport-http": "0.10.1"
+    "zipkin-transport-http": "0.11.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
Sending the accept header causes Zipkin to respond with 404 Not found which is fixed by removing the accept header.,
Tried with zipkin version 2.14.0.