### PR TITLE
Added support for `protocol` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Alternatively, the hostname, port and service name (used by Zipkin to identify y
 var appzip = require('appmetrics-zipkin')({
   host: 'localhost',
   port: 9411,
+  protocol: 'http',
   serviceName:'frontend',
   sampleRate: 1.0
 });
@@ -25,7 +26,7 @@ var appzip = require('appmetrics-zipkin')({
 
 **Note**: The properties file has precedence over the inline settings
 
-If no configuration details are provided, the endpoint will be _localhost:9411_, the serviceName will be set to the program name that requires appmetrics-zipkin and the sample rate will be 1.0 (100% of requests).
+If no configuration details are provided, the endpoint will be _http://localhost:9411_, the serviceName will be set to the program name that requires appmetrics-zipkin and the sample rate will be 1.0 (100% of requests).
 
 
 ## Usage

--- a/appmetrics-zipkin.js
+++ b/appmetrics-zipkin.js
@@ -53,11 +53,12 @@ module.exports = function(options) {
 
 function start(options) {
   // Set up the zipkin
-  var host, port, serviceName, sampleRate;
+  var host, port, protocol, serviceName, sampleRate;
 
   if (options) {
     host = options['host'];
     port = options['port'];
+    protocol = options['protocol'];
     serviceName = options['serviceName'];
     sampleRate = options['sampleRate'];
   }
@@ -69,6 +70,9 @@ function start(options) {
     }
     if (properties.get('port')) {
       port = properties.get('port');
+    }
+    if (properties.get('protocol')) {
+      protocol = properties.get('protocol');
     }
     if (properties.get('serviceName')) {
       serviceName = properties.get('serviceName');
@@ -87,6 +91,9 @@ function start(options) {
   if (!port) {
     port = 9411;
   }
+  if (!protocol) {
+    protocol = 'http';
+  }
   if (!sampleRate) {
     sampleRate = 1.0;
   }
@@ -102,7 +109,7 @@ function start(options) {
     }
   });
 
-  const zipkinUrl = `http://${host}:${port}`;
+  const zipkinUrl = `${protocol}://${host}:${port}`;
   const recorder = new BatchRecorder({
     logger: new HttpLogger({
       endpoint: `${zipkinUrl}/api/v1/spans`

--- a/appmetrics-zipkin.properties
+++ b/appmetrics-zipkin.properties
@@ -1,4 +1,5 @@
 host=
 port=
+protocol=
 serviceName=
 sampleRate=


### PR DESCRIPTION
This allows for `https` protocol to be used rather than `http`. Default to existing `http` protocol.

Fixes #50 